### PR TITLE
Clean up test case with multi-line string indent.

### DIFF
--- a/spec/PEG.Spec.savi
+++ b/spec/PEG.Spec.savi
@@ -8,21 +8,20 @@
       _JSON.TokenPrinter.new
     )
 
-    // TODO: Use one big string once the Savi formatter gets fixed to not complain.
-    assert: parser.parse!(String.join([
-      <<<{>>>
-      <<<  "Hello": "World!",>>>
-      <<<  "from": {>>>
-      <<<    "name": "savi-lang/PEG",>>>
-      <<<    "easy-as": [1, 2, 3],>>>
-      <<<    "nifty": true,>>>
-      <<<    "overcomplicated": false,>>>
-      <<<    "worse-than": null,>>>
-      <<<    "problems": [],>>>
-      <<<    "utf8": ["Д", "Ⴃ", "𐀀"]>>>
-      <<<  }>>>
-      <<<}>>>
-    ], "\n")) == String.join([
+    assert: parser.parse!(<<<
+      {
+        "Hello": "World!",
+        "from": {
+          "name": "savi-lang/PEG",
+          "easy-as": [1, 2, 3],
+          "nifty": true,
+          "overcomplicated": false,
+          "worse-than": null,
+          "problems": [],
+          "utf8": ["Д", "Ⴃ", "𐀀"]
+        }
+      }
+    >>>) == String.join([
       "0-222: _JSON.Token.Object"   // {
       "4-21: _JSON.Token.Pair"
       "5-10: _JSON.Token.String"    // "Hello":


### PR DESCRIPTION
A deficiency in the Savi formatter made it try to correct multi-line strings that had varying indentation, such as this JSON string example. So at the time, the workaround was to use `String.join` with a string for each line.

But now that the latest Savi release has a fix for the formatter, we can fix this test case here.